### PR TITLE
move th text before arrow icons

### DIFF
--- a/components/table/TableHead.js
+++ b/components/table/TableHead.js
@@ -11,13 +11,13 @@ const factory = (Checkbox, FontIcon) => {
           key={key}
           className={onClick && theme.clickable}
           onClick={onClick}>
+          {name}
           {sortColumn === key && sortDirection === 'asc'
             && <FontIcon value="arrow_upward" className={theme.ascIcon} />
           }
           {sortColumn === key && sortDirection === 'desc'
             && <FontIcon value="arrow_downward" className={theme.descIcon} />
           }
-          {name}
         </th>
       );
     });


### PR DESCRIPTION
Moving text lets us use CSS to transform the first letters of the TH element